### PR TITLE
enhancements for onix 3 support

### DIFF
--- a/lib/onix/contributor.rb
+++ b/lib/onix/contributor.rb
@@ -6,7 +6,7 @@ require 'onix/contributor_place'
 module ONIX
   class Contributor < SubsetDSL
     element "SequenceNumber", :integer, :cardinality => 0..1
-    element "ContributorRole", :subset, :shortcut => :role, :cardinality => 1..n
+    elements "ContributorRole", :subset, :shortcut => :roles, :cardinality => 1..n
     elements "FromLanguage", :subset, :klass => "LanguageCode", :cardinality => 0..n
     elements "ToLanguage", :subset, :klass => "LanguageCode", :cardinality => 0..n
 

--- a/lib/onix/onix_message.rb
+++ b/lib/onix/onix_message.rb
@@ -104,6 +104,19 @@ module ONIX
       xml
     end
 
+    def reader(file_path)
+      @reader = Nokogiri::XML::Reader(File.open(file_path, 'r'))
+    end
+
+    def each(&block)
+      @reader.each do |node|
+        if @reader.node_type == 1 && @reader.name == "Product"
+          element = Nokogiri::XML(@reader.outer_xml).at('Product')
+          yield self.product_klass.parse(element)
+        end
+      end
+    end
+
     # release as an integer eg: 210, 300, 301
     # @return [Number]
     def version
@@ -125,12 +138,14 @@ module ONIX
     end
 
     def set_release_from_xml(node, force_release)
+      if force_release
+        @release = force_release.to_s
+        return
+      end
+
       @release = node["release"]
       unless @release
         @release = detect_release(node)
-      end
-      if force_release
-        @release = force_release.to_s
       end
     end
 

--- a/lib/onix/subset.rb
+++ b/lib/onix/subset.rb
@@ -1,5 +1,6 @@
 require 'forwardable'
 require 'cgi'
+require 'delegate'
 
 module ONIX
   class ShortToRef


### PR DESCRIPTION
* Small update to support ruby 2.7 (need an explicit require for `SimpleDelegator`)
* ContributorRoles is now a many elements field, rather than single. A Contributor can have multiple ContributorRoles: eg Author & Narrator. Most publishers just create full Contributor's per-role, but others, if the rest of the information is shared (aka it's the same person), they will just add additional ContributorRoles
* Adding the ability to use `Nokogiri::XML::Reader` rather than a full `Nokogiri::XML.parse` - the latter pulls the entire onix file into memory first, while the `Reader` will stream each node into memory, so is overall less memory intensive. This matches Cacofonix's strategy as well, which under benchmarking was faster than im_onix.