### PR TITLE
collection sequence fix

### DIFF
--- a/lib/onix/serializer.rb
+++ b/lib/onix/serializer.rb
@@ -67,14 +67,12 @@ module ONIX
 
     module Default
       def self.serialize(xml, subset, tag = nil)
-        byebug
         ONIX::Serializer::Traverser.serialize(Default, xml, subset, tag)
       end
 
       class Root
         def self.serialize(xml, subset, tag, level = 0)
-          byebug
-          root_options = {} #subset.version && subset.version >= 300 ? { :xmlns => "http://ns.editeur.org/onix/3.0/reference", :release => subset.release } : {}
+          root_options = subset.version && subset.version >= 300 ? { :xmlns => "http://ns.editeur.org/onix/3.0/reference", :release => subset.release } : {}
           xml.send(tag, root_options) {
             ONIX::Serializer::Traverser.recursive_serialize(Default, xml, subset, tag, level + 1)
           }


### PR DESCRIPTION
We were dropping `CollectionSequenceNumber` when running through the serialize (in nest we call in normalize) step. Looks like there are no other `element.*:string` definitions, and other similar/simple elements use `:text`. 

I will admit that I didn't trace down exactly where this was causing issues, and/or why something didn't fail a bit louder when an invalid type was used. 

Either way, this is working in nest, and there are no other `element.*:string` to update, so this looks like an isolated bug. 