### PR TITLE
Allow unnamed persons parsing and allow more than 1 edition type

### DIFF
--- a/lib/onix/contributor.rb
+++ b/lib/onix/contributor.rb
@@ -31,7 +31,7 @@ module ONIX
     element "CorporateName", :text, :cardinality => 0..1
     element "CorporateNameInverted", :text, :cardinality => 0..1
 
-    # element "UnnamedPersons", :subset, :cardinality => 0..1
+    element "UnnamedPersons", :subset, :cardinality => 0..1
     # elements "AlternativeName", :subset, :cardinality => 0..n
 
 

--- a/lib/onix/descriptive_detail.rb
+++ b/lib/onix/descriptive_detail.rb
@@ -48,7 +48,7 @@ module ONIX
     # elements "Event", :subset, :cardinality => 0..n
 
 
-    element "EditionType", :subset, :cardinality => 0..n
+    elements "EditionType", :subset, :cardinality => 0..n
     element "EditionNumber", :integer, :cardinality => 0..1
     element "EditionVersionNumber", :text, :cardinality => 0..1
     elements "EditionStatement", :text, :cardinality => 0..n


### PR DESCRIPTION
Sometimes the im_onix gem has defaults we don't agree with.

- any field that has a cardinality of 0..n should have a plural `elements`, in this case `EditionType`
- we want to start parsing the `UnnamedPersons` element