### PR TITLE
parse price identifiers for spotify content price type

### DIFF
--- a/lib/onix/identifier.rb
+++ b/lib/onix/identifier.rb
@@ -49,10 +49,14 @@ module ONIX
     identifier_elements "CollectionIDType"
   end
 
+  class PriceIdentifier < Identifier
+    identifier_elements "PriceIDType"
+  end
+
   class ProductIdentifier < Identifier
     identifier_elements "ProductIDType"
   end
-
+  
   class ProductContactIdentifier < Identifier
     identifier_elements "ProductContactIDType"
   end

--- a/lib/onix/price.rb
+++ b/lib/onix/price.rb
@@ -7,8 +7,6 @@ require 'onix/comparison_product_price'
 
 module ONIX
   class Price < SubsetDSL
-    include IdentifiersMethods::ProprietaryId
-
     elements "PriceIdentifier", :subset, :cardinality => 0..n
 
     element "PriceType", :subset, :shortcut => :type, :cardinality => 0..1

--- a/lib/onix/price.rb
+++ b/lib/onix/price.rb
@@ -7,8 +7,7 @@ require 'onix/comparison_product_price'
 
 module ONIX
   class Price < SubsetDSL
-    elements "PriceIdentifier", :subset, :cardinality => 0..n
-
+    elements "PriceIdentifier", :subset, :shortcut => :identifiers, :cardinality => 0..n
 
     element "PriceType", :subset, :shortcut => :type, :cardinality => 0..1
     element "PriceQualifier", :subset, :shortcut => :qualifier, :cardinality => 0..1

--- a/lib/onix/price.rb
+++ b/lib/onix/price.rb
@@ -7,7 +7,9 @@ require 'onix/comparison_product_price'
 
 module ONIX
   class Price < SubsetDSL
-    elements "PriceIdentifier", :subset, :shortcut => :identifiers, :cardinality => 0..n
+    include IdentifiersMethods::ProprietaryId
+
+    elements "PriceIdentifier", :subset, :cardinality => 0..n
 
     element "PriceType", :subset, :shortcut => :type, :cardinality => 0..1
     element "PriceQualifier", :subset, :shortcut => :qualifier, :cardinality => 0..1

--- a/lib/onix/price.rb
+++ b/lib/onix/price.rb
@@ -7,7 +7,7 @@ require 'onix/comparison_product_price'
 
 module ONIX
   class Price < SubsetDSL
-    # elements "PriceIdentifier", :subset, :cardinality => 0..n
+    elements "PriceIdentifier", :subset, :cardinality => 0..n
 
 
     element "PriceType", :subset, :shortcut => :type, :cardinality => 0..1


### PR DESCRIPTION
Seems like we'll need to use price type identifiers to parse product content and list price for Spotify:

<img width="462" alt="Screenshot 2023-09-12 at 12 23 12 PM" src="https://github.com/BookBub/im_onix/assets/20650656/4e345fe2-0025-486c-9ac1-2b75282ae203">
